### PR TITLE
Fix/domain get context fix

### DIFF
--- a/addons/account_payment/account_payment.py
+++ b/addons/account_payment/account_payment.py
@@ -265,27 +265,27 @@ class payment_line(osv.osv):
                 date = time.strftime('%Y-%m-%d')
         return date
 
-    def _get_ml_inv_ref(self, cr, uid, ids, *a):
+    def _get_ml_inv_ref(self, cr, uid, ids, field, arg, context=None):
         res = {}
-        for id in self.browse(cr, uid, ids):
+        for id in self.browse(cr, uid, ids, context=context):
             res[id.id] = False
             if id.move_line_id:
                 if id.move_line_id.invoice:
                     res[id.id] = id.move_line_id.invoice.id
         return res
 
-    def _get_ml_maturity_date(self, cr, uid, ids, *a):
+    def _get_ml_maturity_date(self, cr, uid, ids, field, arg, context=None):
         res = {}
-        for id in self.browse(cr, uid, ids):
+        for id in self.browse(cr, uid, ids, context=context):
             if id.move_line_id:
                 res[id.id] = id.move_line_id.date_maturity
             else:
                 res[id.id] = False
         return res
 
-    def _get_ml_created_date(self, cr, uid, ids, *a):
+    def _get_ml_created_date(self, cr, uid, ids, field, arg, context=None):
         res = {}
-        for id in self.browse(cr, uid, ids):
+        for id in self.browse(cr, uid, ids, context=context):
             if id.move_line_id:
                 res[id.id] = id.move_line_id.date_created
             else:

--- a/openerp/addons/base/ir/ir_rule.py
+++ b/openerp/addons/base/ir/ir_rule.py
@@ -153,7 +153,7 @@ class ir_rule(osv.osv):
             # involve objects on which the real uid has no acces rights.
             # This means also there is no implicit restriction (e.g. an object
             # references another object the user can't see).
-            query = self.pool[model_name]._where_calc(cr, SUPERUSER_ID, dom, active_test=False)
+            query = self.pool[model_name]._where_calc(cr, SUPERUSER_ID, dom, active_test=False, context=context)
             return query.where_clause, query.where_clause_params, query.tables
         return [], [], ['"' + self.pool[model_name]._table + '"']
 


### PR DESCRIPTION
This PR fixes 2 things:
1. Pass the context to the _where_calc function when called from domain_get on ir.rule access validations
2. Select the appropriate context value to pass to the browse method.
