### PR TITLE
[FIX][8.0] Bigint, apply Apache extensions namespace

### DIFF
--- a/openerp/service/wsgi_server.py
+++ b/openerp/service/wsgi_server.py
@@ -33,6 +33,7 @@ import StringIO
 import errno
 import logging
 import platform
+import re
 import socket
 import sys
 import threading
@@ -102,6 +103,11 @@ def xmlrpc_return(start_response, service, method, params, string_faultcode=Fals
             response = xmlrpc_handle_exception_string(e)
         else:
             response = xmlrpc_handle_exception_int(e)
+    # Inject Apache extension namespace
+    response = re.sub(
+        r'(^<\?xml([^>]+)>\s*)<methodResponse>',
+        r'\1<methodResponse xmlns:ex="http://ws.apache.org/xmlrpc/namespaces/extensions">',
+        response)
     start_response("200 OK", [('Content-Type','text/xml'), ('Content-Length', str(len(response)))])
     return [response]
 

--- a/openerp/service/wsgi_server.py
+++ b/openerp/service/wsgi_server.py
@@ -54,14 +54,14 @@ MINLONG = -2L**63
 def dump_long(_self, value, write):
     if value > MAXLONG or value < MINLONG:
         raise OverflowError, "long exceeds XML-RPC limits"
-    write("<value><i8>")
+    write("<value><ex:i8>")
     write(str(int(value)))
-    write("</i8></value>\n")
+    write("</ex:i8></value>\n")
 
 def dump_int(_self, value, write):
     if value > MAXLONG or value < MINLONG:
         raise OverflowError, "int exceeds XML-RPC limits"
-    tag = 'i8' if value > xmlrpclib.MAXINT or value < xmlrpclib.MININT else 'int'
+    tag = 'ex:i8' if value > xmlrpclib.MAXINT or value < xmlrpclib.MININT else 'int'
     write("<value><%s>" % tag)
     write(str(int(value)))
     write("</%s></value>\n" % tag)


### PR DESCRIPTION
Apparently, i8 responses cannot be parsed by Java clients after all so reapply ex:i8 but with namespace.